### PR TITLE
Contract fixes

### DIFF
--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -59,6 +59,8 @@ contract VoteProposalPool {
     )
         external
         validateDeadline(_deadline)
+        validateName(_name)
+        validateDescription(_data)
         returns (VoteProposal newProposal)
     {
         newProposal = new VoteProposal(_deadline, _name, _data);
@@ -79,6 +81,19 @@ contract VoteProposalPool {
     modifier validateDeadline(uint32 _deadline) {
         require(_deadline > (now + 604800), "Deadline must be at least one week from now");
         require(_deadline < (now + 31622400), "Deadline must be no more than one year from now");
+        _;
+    }
+
+    modifier validateName(string memory _name) {
+        bytes memory nameBytes = bytes(_name);
+        require(nameBytes.length < 32, "Proposal name must be less than 32 characters (ASCII)");
+        require(nameBytes.length >= 4, "Proposal name at least 4 characters (ASCII)");
+        _;
+    }
+
+    modifier validateDescription(string memory _description) {
+        bytes memory descriptionBytes = bytes(_description);
+        require(descriptionBytes.length < 256, "Proposal description must be less than 256 characters (ASCII)");
         _;
     }
 

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.5.0;
 contract VoteOption {
     VoteProposal creator;
     address owner;
-    uint deadline;
+    uint32 deadline;
     string name;
     string option;
 
-    constructor(uint _deadline, string memory _name, string memory _option) public {
+    constructor(uint32 _deadline, string memory _name, string memory _option) public {
         owner = msg.sender;
         creator = VoteProposal(msg.sender);
         deadline = _deadline;
@@ -25,13 +25,13 @@ contract VoteOption {
 contract VoteProposal {
     VoteProposalPool creator;
     address owner;
-    uint deadline;
+    uint32 deadline;
     string name;
     string data;
 
     mapping(uint => address) public options;
 
-    constructor(uint _deadline, string memory _name, string memory _data) public {
+    constructor(uint32 _deadline, string memory _name, string memory _data) public {
         owner = msg.sender;
         creator = VoteProposalPool(msg.sender);
         deadline = _deadline;
@@ -39,7 +39,7 @@ contract VoteProposal {
         data = _data;
     }
 
-    function createOptions(uint _deadline, string calldata _name)
+    function createOptions(uint32 _deadline, string calldata _name)
         external
         returns (VoteOption yes, VoteOption no)
     {
@@ -55,7 +55,7 @@ contract VoteProposalPool {
     function newVoteProposal(
         string calldata _name,
         string calldata _data,
-        uint64 _deadline
+        uint32 _deadline
     )
         external
         validateDeadline(_deadline)
@@ -76,7 +76,7 @@ contract VoteProposalPool {
     }
 
 
-    modifier validateDeadline(uint _newDeadline) {
+    modifier validateDeadline(uint32 _newDeadline) {
       require(_newDeadline > now);
       _;
     }
@@ -84,7 +84,7 @@ contract VoteProposalPool {
     event newProposalIssued(
         address proposal,
         address issuer,
-        uint deadline,
+        uint32 deadline,
         string name,
         string data,
         string optionA,

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -17,7 +17,7 @@ contract VoteOption {
 
     event AnonymousDeposit(address indexed from, uint value, string name, string option);
 
-    function () external payable {
+    receive() external payable {
 	    emit AnonymousDeposit(msg.sender, msg.value, name, option);
     }
 }

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -76,9 +76,10 @@ contract VoteProposalPool {
     }
 
 
-    modifier validateDeadline(uint32 _newDeadline) {
-      require(_newDeadline > now);
-      _;
+    modifier validateDeadline(uint32 _deadline) {
+        require(_deadline > (now + 604800), "Deadline must be at least one week from now");
+        require(_deadline < (now + 31622400), "Deadline must be no more than one year from now");
+        _;
     }
 
     event newProposalIssued(

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.0;
 contract VoteOption {
     VoteProposal creator;
     address owner;
-    address voteOptionAddress;
     uint deadline;
     string name;
     string option;
@@ -11,7 +10,6 @@ contract VoteOption {
     constructor(uint _deadline, string memory _name, string memory _option) public {
         owner = msg.sender;
         creator = VoteProposal(msg.sender);
-        voteOptionAddress = address(this);
         deadline = _deadline;
         name = _name;
         option = _option;
@@ -20,7 +18,7 @@ contract VoteOption {
     event AnonymousDeposit(address indexed from, uint value, string name, string option);
 
     function () external payable {
-		emit AnonymousDeposit(msg.sender, msg.value, name, option);
+	    emit AnonymousDeposit(msg.sender, msg.value, name, option);
     }
 }
 
@@ -43,13 +41,12 @@ contract VoteProposal {
 
     function createOptions(uint _deadline, string calldata _name)
         external
-        returns (VoteOption newVoteOptionA, VoteOption newVoteOptionB)
+        returns (VoteOption yes, VoteOption no)
     {
-        VoteOption yes = new VoteOption(_deadline, _name, "yes");
-        VoteOption no = new VoteOption(_deadline, _name, "no");
+        yes = new VoteOption(_deadline, _name, "yes");
+        no = new VoteOption(_deadline, _name, "no");
         options[0] = address(yes);
         options[1] = address(no);
-        return (yes, no);
     }
 }
 
@@ -64,19 +61,18 @@ contract VoteProposalPool {
         validateDeadline(_deadline)
         returns (VoteProposal newProposal)
     {
-        VoteProposal proposal = new VoteProposal(_deadline, _name, _data);
-        proposal.createOptions(_deadline, _name);
+        newProposal = new VoteProposal(_deadline, _name, _data);
+        newProposal.createOptions(_deadline, _name);
         emit newProposalIssued(
-            address(proposal),
+            address(newProposal),
             msg.sender,
             _deadline,
             _name,
             _data,
             "yes",
-            proposal.options(0),
+            newProposal.options(0),
             "no",
-            proposal.options(1));
-        return (proposal);
+            newProposal.options(1));
     }
 
 

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -67,7 +67,7 @@ contract VoteProposalPool {
         VoteProposal proposal = new VoteProposal(_deadline, _name, _data);
         proposal.createOptions(_deadline, _name);
         emit newProposalIssued(
-            proposal,
+            address(proposal),
             msg.sender,
             _deadline,
             _name,

--- a/burnSignal.sol
+++ b/burnSignal.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 contract VoteOption {
     VoteProposal creator;


### PR DESCRIPTION
Addresses https://github.com/burnSignal/burnSignal-Spec/issues/16 and add other improvements:

- Restrict deadline validation to more than one week from now and less than one year
- Restrict the length of accepted proposal names (4 <= name < 32 bytes) and descriptions (< 256 bytes)
- bump compiler version and add newly introduced `receive()` fallback function to `VoteOption` contract